### PR TITLE
add support to accepts an array of route objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 .DS_Store
 coverage
+.idea/

--- a/README.md
+++ b/README.md
@@ -103,8 +103,30 @@ var Joi = router.Joi;
 
 ### .route()
 
-Adds a new route to the router. `route()` accepts an object describing everything about
+Adds a new route to the router. `route()` accepts an object or array of objects describing everything about
 the routes behavior.
+
+```js
+var router = require('koa-joi-router');
+var public = router();
+
+var routes = [
+  {
+    method: 'post',
+    path: '/users',
+    handler: function*(){}
+  },
+  {
+    method: 'get',
+    path: '/users',
+    handler: function*(){}
+  }
+];
+
+public.route(routes);
+```
+
+or
 
 ```js
 var router = require('koa-joi-router');

--- a/joi-router.js
+++ b/joi-router.js
@@ -52,7 +52,7 @@ Router.prototype.middleware = function middleware() {
 };
 
 /**
- * Adds a route to this router, storing the route
+ * Adds a route or array of routes to this router, storing the route
  * in `this.routes`.
  *
  * Example:
@@ -86,6 +86,26 @@ Router.prototype.middleware = function middleware() {
  */
 
 Router.prototype.route = function route(spec) {
+  if (Array.isArray(spec)) {
+    for (var i = 0; i < spec.length; i++) {
+      this._addRoute(spec[i]);
+    }
+  } else {
+    this._addRoute(spec);
+  }
+
+  return this;
+};
+
+/**
+ * Adds a route to this router, storing the route
+ * in `this.routes`.
+ *
+ * @param {Object} spec
+ * @api private
+ */
+
+Router.prototype._addRoute = function addRoute(spec) {
   this._validateRouteSpec(spec);
   this.routes.push(spec);
 
@@ -107,8 +127,6 @@ Router.prototype.route = function route(spec) {
   spec.method.forEach(function(method) {
     router[method].apply(router, args);
   });
-
-  return this;
 };
 
 /**
@@ -441,4 +459,3 @@ methods.forEach(function(method) {
     return this;
   };
 });
-

--- a/test/index.js
+++ b/test/index.js
@@ -158,7 +158,7 @@ describe('koa-joi-router', function() {
       });
     });
 
-    it('adds routes to the routes array', function(done) {
+    it('adds route to the routes array', function(done) {
       var r = router();
       assert.equal(0, r.routes.length);
 
@@ -169,6 +169,27 @@ describe('koa-joi-router', function() {
       });
 
       assert.equal(1, r.routes.length);
+      done();
+    });
+
+    it('adds routes to the routes array', function(done) {
+      var r = router();
+      assert.equal(0, r.routes.length);
+
+      r.route([
+        {
+          method: 'put',
+          path: '/asdf/:id',
+          handler: function*() {}
+        },
+        {
+          method: 'get',
+          path: '/asdf/:id',
+          handler: function*() {}
+        }
+      ]);
+
+      assert.equal(2, r.routes.length);
       done();
     });
 


### PR DESCRIPTION
I like to define array of routes in my [application](https://github.com/martinmicunda/employee-scheduling-api/blob/master/lib%2Fapi%2Fpartners%2Findex.js#L17) same like in `hapi` so I have added option to pass array to `route()` function.  `route()` accepts an object or array of objects now.

```js
var router = require('koa-joi-router');
var public = router();

var routes = [
  {
    method: 'post',
    path: '/users',
    handler: function*(){}
  },
  {
    method: 'get',
    path: '/users',
    handler: function*(){}
  }
];

public.route(routes);
```

* [x] test
* [x] coverage
* [x] doc