### PR TITLE
trigger output validation only for response status code between 200 a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,9 @@ By default, `koa-joi-router` stops processing the middleware stack when either
 input validation fails. This means your route will not be reached. If
 this isn't what you want, for example, if you're writing a web app which needs
 to respond with custom html describing the errors, set the `validate.continueOnError`
-flag to true. You can find out if validation failed by checking `ctx.invalid`.
+flag to true. You can find out if validation failed by checking `ctx.invalid`. If you're 
+define output validation only a response status code between 200 and 299 is considered 
+for output validation.
 
 ```js
 admin.route({

--- a/joi-router.js
+++ b/joi-router.js
@@ -325,7 +325,7 @@ function makeValidator(spec) {
 
     yield* next;
 
-    if (spec.validate.output) {
+    if (spec.validate.output && this.status >= 200 && this.status < 300) {
       err = validateOutput(this, spec);
       if (err) return this.throw(err);
     }

--- a/test/index.js
+++ b/test/index.js
@@ -1096,6 +1096,29 @@ describe('koa-joi-router', function() {
           });
         });
       });
+
+      describe('status is respond status is greater than 300', function() {
+        var r = router();
+
+        r.route({
+          method: 'post',
+          path: '/a/b',
+          validate: {
+            output: Joi.number().max(10).required()
+          },
+          handler: function*() {
+            this.body = 'not found';
+            this.status = 404;
+          }
+        });
+
+        var app = koa();
+        app.use(r.middleware());
+
+        it('responds with the response body', function(done) {
+          test(app).post('/a/b').expect('not found').expect(404, done);
+        });
+      });
     });
 
     describe('with multiple methods', function() {


### PR DESCRIPTION
This pull fix the problem when I want to validate output respond body but there is 404, 409 or some other errors so in this case we should not validate respond and pass error to the user or some other middleware.

In current code when I return error 400 e.g. from my database the `koa-joi-router` try validate output however as this is 404 error it will throw error because respond body is invalid and it set response status to 500 and this incorrect behaviour instead it should not validate respond status and let pass error to parent or directly to user to notify that resource was not found.

- [x] Test
- [x] Coverage
- [x] Doc