### PR TITLE
Test and Fixes for #6 - Dates in querystring become empty strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 test: mocha lint
 
 mocha:
-	@NODE_ENV=test ./node_modules/.bin/mocha $(MOCHA_OPTS)
+	@NODE_ENV=test ./node_modules/.bin/mocha --harmony-generators $(MOCHA_OPTS)
 
 lint:
 	@ find . -name "*.js" \

--- a/joi-router.js
+++ b/joi-router.js
@@ -373,13 +373,16 @@ function validateInput(prop, request, validate) {
   } else {
     if (prop === 'query') {
       var dateKeys = [];
+      var boolKeys = [];
       Object.keys(res.value).forEach(function(key) {
         if (res.value[key] instanceof Date) {
           dateKeys.push(key);
           res.value[key] = res.value[key].toISOString();
+        } else if (res.value[key] === true || res.value[key] === false) {
+          boolKeys.push(key);
         }
       });
-      if (dateKeys.length > 0) {
+      if (dateKeys.length > 0 || boolKeys.length > 0) {
         Object.defineProperty(request, 'query', {
           set: function(obj) {
             this.querystring = qs.stringify(obj);
@@ -394,6 +397,9 @@ function validateInput(prop, request, validate) {
               var query = qs.parse(request.querystring);
               dateKeys.forEach(function(key) {
                 query[key] = new Date(query[key]);
+              });
+              boolKeys.forEach(function(key) {
+                query[key] = query[key] === 'true';
               });
               cache[request.querystring] = query;
               return query;

--- a/test/index.js
+++ b/test/index.js
@@ -575,6 +575,91 @@ describe('koa-joi-router', function() {
           .expect(200, done);
         });
       });
+
+      describe('json or form', function() {
+        describe('and valid json is sent', function() {
+          it('is parsed as json', function(done) {
+            var r = router();
+
+            r.route({
+              method: 'post',
+              path: '/',
+              handler: fn,
+              validate: {
+                type: ['json','form']
+              }
+            });
+
+            function* fn() {
+              this.body = this.request.body.last + ' ' + this.request.body.first;
+            }
+
+            var app = koa();
+            app.use(r.middleware());
+            test(app).post('/')
+                .send({
+                  last: 'Heckmann',
+                  first: 'Aaron'
+                })
+                .expect(200)
+                .expect('Heckmann Aaron', done);
+          });
+        });
+
+        describe('and valid form is sent', function() {
+          it('is parsed as form', function(done) {
+            var r = router();
+
+            r.route({
+              method: 'post',
+              path: '/',
+              handler: function*() {
+                this.status = 204;
+              },
+              validate: {
+                type: ['json','form']
+              }
+            });
+
+            var app = koa();
+            app.use(r.middleware());
+
+            test(app)
+                .post('/')
+                .type('form')
+                .send({
+                  name: 'Pebble'
+                })
+                .expect(204, done);
+          });
+        });
+
+        describe('and neither json nor form is sent', function() {
+          it('fails', function(done) {
+            var r = router();
+
+            r.route({
+              method: 'post',
+              path: '/',
+              handler: function*() {
+                this.status = 204;
+              },
+              validate: {
+                type: 'json'
+              }
+            });
+
+            var app = koa();
+            app.use(r.middleware());
+
+            test(app)
+                .post('/')
+                .type('text')
+                .send('text')
+                .expect(400, done);
+          });
+        });
+      })
     });
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -655,7 +655,8 @@ describe('koa-joi-router', function() {
             query: Joi.object().keys({
               q: Joi.number().min(5).max(8).required(),
               s: Joi.string().alphanum().length(6),
-              d: Joi.date().iso()
+              d: Joi.date().iso(),
+              b: Joi.boolean()
             }).options({
               allowUnknown: true
             })
@@ -664,9 +665,16 @@ describe('koa-joi-router', function() {
             if (this.request.query.d !== undefined &&
                 !(this.request.query.d instanceof Date)) {
               this.status = 400;
-            } else {
-              this.body = this.request.query;
+              return;
             }
+
+            if (this.request.query.b !== undefined &&
+                typeof this.request.query.b !== 'boolean') {
+              this.status = 400;
+              return;
+            }
+
+            this.body = this.request.query;
           }
         });
 
@@ -720,6 +728,16 @@ describe('koa-joi-router', function() {
             if (err) return done(err);
             assert.equal(200, res.statusCode);
             assert.equal(timestamp.toISOString(), res.body.d);
+            done(err);
+          });
+        });
+
+        it('valid q and valid b', function(done) {
+          test(app).get('/a?q=5&b=true')
+          .end(function(err, res) {
+            if (err) return done(err);
+            assert.equal(200, res.statusCode);
+            assert.equal(true, res.body.b);
             done(err);
           });
         });

--- a/test/index.js
+++ b/test/index.js
@@ -654,13 +654,19 @@ describe('koa-joi-router', function() {
           validate: {
             query: Joi.object().keys({
               q: Joi.number().min(5).max(8).required(),
-              s: Joi.string().alphanum().length(6)
+              s: Joi.string().alphanum().length(6),
+              d: Joi.date().iso()
             }).options({
               allowUnknown: true
             })
           },
           handler: function*() {
-            this.body = this.request.query;
+            if (this.request.query.d !== undefined &&
+                !(this.request.query.d instanceof Date)) {
+              this.status = 400;
+            } else {
+              this.body = this.request.query;
+            }
           }
         });
 
@@ -703,6 +709,17 @@ describe('koa-joi-router', function() {
             assert.equal(5, res.body.q);
             assert.equal('as9fgh', res.body.s);
             assert.equal(10, res.body.sort);
+            done(err);
+          });
+        });
+
+        it('valid q and valid d', function(done) {
+          var timestamp = new Date();
+          test(app).get('/a?q=5&d=' + timestamp.toISOString())
+          .end(function(err, res) {
+            if (err) return done(err);
+            assert.equal(200, res.statusCode);
+            assert.equal(timestamp.toISOString(), res.body.d);
             done(err);
           });
         });


### PR DESCRIPTION
Added test case for ISO date in query string to prove it fails
Overwrite koa request's property `query` to handle dates correctly.